### PR TITLE
Disable Ledgedash code on Ultimate profile

### DIFF
--- a/code/DIYB0XX-v1.209/DIYB0XX-v1.209.ino
+++ b/code/DIYB0XX-v1.209/DIYB0XX-v1.209.ino
@@ -431,7 +431,7 @@ void loop()
     }
   }
 
-  if (isLEFT && isRIGHT && !VERTICAL)
+  if (isLEFT && isRIGHT && !VERTICAL && (currentGame != Ultimate))
     controlX = 128 + (positionX * 100);
 
 

--- a/code/DIYSmashB0XX-v1.209/DIYSmashB0XX-v1.209.ino
+++ b/code/DIYSmashB0XX-v1.209/DIYSmashB0XX-v1.209.ino
@@ -428,7 +428,7 @@ void loop()
     }
   }
 
-  if (isLEFT && isRIGHT && !VERTICAL)
+  if (isLEFT && isRIGHT && !VERTICAL && (currentGame != Ultimate))
     controlX = 128 + (positionX * 100);
 
 


### PR DESCRIPTION
Currently, the code for Ledgedashing which bypasses ModX when both horizontal directions are pressed applies regardless of profile, except in the NativeUSB code. This change would disable this code when the Ultimate profile is in use as its benefits do not apply in that game and it can get in the way when trying to do sliding ftilt etc.